### PR TITLE
switched to using destructured breakpoints instead of theme.breakpoint.down/up

### DIFF
--- a/src/components/MainContent/MainContentStyles.js
+++ b/src/components/MainContent/MainContentStyles.js
@@ -1,24 +1,10 @@
-import { createTheme } from "@mui/material";
-
-const theme = createTheme();
-
 const classes = {
     main_content_paper_container: {
         height: '100%',
-        marginLeft: "1rem",
-        padding: "1.5rem",
+        marginLeft: { sm: "0rem", lg: "1rem"},
+        padding: { sm: ".5rem", lg: "1.5rem"},
         overflow: "scroll",
-        width: "75%",
-        [theme.breakpoints.down("1000")]: {
-            width: '98%',
-            marginLeft: "0rem",
-            padding: ".5rem",
-        },
-        [theme.breakpoints.down("420")]: {
-            width: '98%',
-            marginLeft: "0rem",
-            padding: ".5rem",
-        },
+        width: { sm: "98%", lg: "75%"},
     },
     main_content_icon: {
         marginBottom: "1rem"
@@ -26,84 +12,44 @@ const classes = {
     main_content_header: {
         fontWeight: "bold", 
         fontSize: { xs: "3rem" },
-        [theme.breakpoints.down("1000")]: {
-            textAlign: "center",
-        }
+        textAlign: { xs: "center", lg: "left" },
     },
     main_content_sub_header: {
         color: "teal", 
         marginBottom: "2.5rem",
-        [theme.breakpoints.down("1000")]: {
-            textAlign: "center",
-        }
+        textAlign: { xs: "center", lg: "left" },
     },
     main_content_dashboard_sales_client_traffic: {
         display: "flex",
         overflow: "scroll",
         width: "100%",
-        [theme.breakpoints.down("1000")]: {
-            justifyContent: "center",
-        },
-        [theme.breakpoints.down("600")]: {
-            flexDirection: "column",
-            placeItems: "center",
-        }
+        justifyContent: { xs: "center", lg: "start" },
+        flexDirection: { xs: "column", md: "row" },
+        placeItems: { xs: "center", lg: "start" },
     },
     main_content_big_dashboard_container: {
         display: "flex",
         marginTop: "2rem",
         height: "55%",
-        [theme.breakpoints.down("md")]: {
-            flexDirection: "column",
-            placeItems: "center",
-        },
-        [theme.breakpoints.down("1000")]: {
-            flexDirection: 'column',
-            placeItems: "center",
-        }
+        flexDirection: { xs: "column", lg: "row" },
+        placeItems: { xs: "center", lg: "start" },
     },
     main_content_dashboard_revenue_generated_container: {
         backgroundColor: "#f4f4f4", 
         padding: "2rem",
         flexGrow: "1",
-        height: "auto",
-        [theme.breakpoints.down("1000")]: {
-            width: "400px",
-            maxHeight: "200px",
-            textAlign: 'center',
-        },  
-        [theme.breakpoints.down("md")]: {
-            width: "400px",
-            maxHeight: "200px",
-            textAlign: 'center',
-        },
-        [theme.breakpoints.down("510")]: {
-            width: "300px",
-        },
+        height: { xs: "200px", md: "250px", lg: "700px" },
+        width: { xs: "325px", md: "82%", lg: "33%" },
+        textAlign: { xs: "center", lg: "left" },
     },
     main_content_dashboard_recent_transactions_container: {
-        marginLeft: '2rem', 
         backgroundColor: "#f4f4f4",
+        marginTop: {xs: "1rem", lg: "0rem"},
+        marginLeft: { xs: "0rem", lg: "2rem" }, 
         padding: "2rem",
-        height: "auto",
-        width: "325px",
+        height: { xs: "350px", md: "400px", lg: "700px" },
+        width: { xs: "325px", md: "82%", lg: "325px" },
         overflow: "scroll",
-        [theme.breakpoints.down("1000")]: {
-            width: "400px",
-            marginTop: "1rem",
-            marginLeft: "0rem",
-            maxHeight: "350px",
-        },
-        [theme.breakpoints.down("md")]: {
-            marginLeft: "0rem",
-            marginTop: "1rem",
-            height: "350px",
-        },
-        [theme.breakpoints.down("510")]: {
-            width: "300px",
-            marginTop: "1rem",
-            marginLeft: "0rem",
-        },
     },
     main_content_divider: {
         marginTop: '1rem', 

--- a/src/components/MiniDashboard/MiniDashboardStyles.js
+++ b/src/components/MiniDashboard/MiniDashboardStyles.js
@@ -10,24 +10,17 @@ const classes = {
         backgroundColor: '#f4f4f4', 
         padding: '1rem', 
         height:"125px", 
-        width: "25%",
-        [theme.breakpoints.down("1000")]: {
-            placeItems: "center",
-        },
-        [theme.breakpoints.down("600")]: {
-            marginLeft: "0rem",
-            marginTop: "1rem",
-            minWidth: "300px",
-            placeItems: "center",
-        }
+        width: { xs: "357px", md: "25%" },
+        placeItems: { xs: "center", lg: "normal" },
+        // need theme.breakpoints for this because the 1st element you don't want to have a marginLeft and you only want this to apply at mobile screen sizes
+        // also theme.breakpoints.down("md") is not using my correct breakpoint of 600, it's using it's default breakpoint of 900, I don't know why
+        [theme.breakpoints.down("600")]: { marginLeft: "0rem",  marginTop: "1rem" }
     },
     main_content_dashboard_sales_clients_trash_percentage: {
         display: 'flex',
         color: 'teal',
-        [theme.breakpoints.down("md")]: {
-            flexDirection: "column",
-            placeItems: "center",
-        }
+        flexDirection: { xs: "column", lg: "row" },
+        placeItems: { xs: "center", lg: "normal" },
     },
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,15 +6,15 @@ import "./index.css";
 
 const theme = createTheme({
 	breakpoints: {
-		values: { xs: 0, sm: 350, md: 600, lg: 900, xl: 1200 },
+		values: { xs: 0, sm: 350, md: 600, lg: 1000, xl: 1200 },
 	},
-  palette: {
-    primary: {
-      main: "#008080",
-      dark: "#045D5D",
-      light: "#00ADAD",
-    },
-  },
+	palette: {
+		primary: {
+			main: "#008080",
+			dark: "#045D5D",
+			light: "#00ADAD",
+		},
+	},
 	components: {
 		MuiButton: {
 			styleOverrides: {


### PR DESCRIPTION
ran into one instance where this change was not possible due to me needing the first component to not have a marginLeft. Also sometimes when forced to use theme.breakpoint.down/up, it will not recognize MY custom breakpoint that I set in the ThemeProvider and will default to its own default MUI breakpoints. So to overcome that you can just change the breakpoint.down(600) instead of breakpoint.down("md")